### PR TITLE
feat(openclaw): add image with bundled chromium

### DIFF
--- a/images/openclaw/Dockerfile
+++ b/images/openclaw/Dockerfile
@@ -1,0 +1,15 @@
+# renovate: datasource=docker depName=ghcr.io/openclaw/openclaw
+ARG OPENCLAW_VERSION=2026.4.22
+
+FROM ghcr.io/openclaw/openclaw:${OPENCLAW_VERSION}
+
+USER root
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        chromium \
+        ca-certificates \
+        fonts-liberation \
+    && rm -rf /var/lib/apt/lists/*
+
+USER node


### PR DESCRIPTION
## Summary
- Adds `images/openclaw/Dockerfile`, layering `chromium` onto the upstream `ghcr.io/openclaw/openclaw` image.
- Upstream ships `playwright-core` but no browser binary, so openclaw's built-in browser plugin fails at runtime with `No supported browser found`. This image fixes that for the homelab deployment.
- Follows existing repo conventions: first `ARG *_VERSION=` at top for the build workflow to pick up, renovate annotation for docker tag tracking.

Built image: `ghcr.io/smauermann/openclaw:2026.4.15`

## Test plan
- [ ] CI build workflow succeeds and pushes `ghcr.io/smauermann/openclaw:2026.4.15`
- [ ] Follow-up homelab PR switches the deployment to this image and sets `browser.executablePath`/`headless`/`noSandbox` per upstream's Linux troubleshooting doc
- [ ] Verify `browser.request` succeeds end-to-end in the running pod