### PR TITLE
feat(renovate): automerge non-major updates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,12 +8,12 @@ on:
       - images/**
       - .github/**
 
+  # No path filter: the "Detect changed images" job is a required status check,
+  # so it must run on every PR (path-filtered workflows never report → merge blocked).
+  # Actual image builds stay gated by the matrix `if` below.
   pull_request:
     branches:
       - main
-    paths:
-      - images/**
-      - .github/**
 
 env:
   REGISTRY: ghcr.io

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,14 @@
     "helpers:pinGitHubActionDigests",
     ":disableRateLimiting"
   ],
+  "packageRules": [
+    {
+      "description": "Automerge non-major updates; only major needs manual approval",
+      "matchUpdateTypes": ["minor", "patch", "digest", "pin", "pinDigest"],
+      "automerge": true,
+      "platformAutomerge": false
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## What

Enable Renovate automerge for **minor, patch, digest and pin** updates. **Major** updates still require manual review/merge.

```json
"packageRules": [
  {
    "description": "Automerge non-major updates; only major needs manual approval",
    "matchUpdateTypes": ["minor", "patch", "digest", "pin", "pinDigest"],
    "automerge": true,
    "platformAutomerge": false
  }
]
```

## Why this works without extra config

- `main` has **no branch protection**, so no human review gates merges.
- `costanza-bot` (the Renovate GitHub App) already opens PRs and pushes commits — it therefore already has `contents:write` + `pull-requests:write`, which is everything needed to merge. No app permission changes required.
- `platformAutomerge: false` makes Renovate merge via its own API call once branch checks are green, rather than GitHub native auto-merge (which would need branch protection + required checks; awkward here because the matrix build produces dynamic check names).

Automerges land on a Renovate run (every 8h) once the build check is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)