### PR TITLE
feat(renovate): faster automerge + fix 1Password CLI datasource

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -7,7 +7,7 @@ on:
     paths:
       - renovate.json
   schedule:
-    - cron: "0 */8 * * *"
+    - cron: "0 */4 * * *"
   workflow_dispatch:
     inputs:
       dryRun:

--- a/images/openclaw/Dockerfile
+++ b/images/openclaw/Dockerfile
@@ -5,7 +5,7 @@ FROM ghcr.io/openclaw/openclaw:${OPENCLAW_VERSION}
 
 USER root
 
-# renovate: datasource=github-releases depName=1Password/1password-cli
+# renovate: datasource=custom.1password-cli depName=1password-cli
 ARG OP_CLI_VERSION=v2.34.0
 
 RUN apt-get update \

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,12 @@
     "helpers:pinGitHubActionDigests",
     ":disableRateLimiting"
   ],
+  "customDatasources": {
+    "1password-cli": {
+      "defaultRegistryUrlTemplate": "https://app-updates.agilebits.com/product_history/CLI2",
+      "format": "html"
+    }
+  },
   "rebaseWhen": "conflicted",
   "packageRules": [
     {
@@ -12,6 +18,12 @@
       "matchUpdateTypes": ["minor", "patch", "digest", "pin", "pinDigest"],
       "automerge": true,
       "platformAutomerge": false
+    },
+    {
+      "description": "1Password CLI publishes via agilebits, not GitHub; pull the version out of the download links",
+      "matchDatasources": ["custom.1password-cli"],
+      "extractVersion": "op2/pkg/(?<version>v[^/]+)/op_linux_amd64_",
+      "versioning": "semver"
     }
   ],
   "customManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     "helpers:pinGitHubActionDigests",
     ":disableRateLimiting"
   ],
+  "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "description": "Automerge non-major updates; only major needs manual approval",


### PR DESCRIPTION
Single PR covering the Renovate follow-ups.

## 1. `rebaseWhen: conflicted` — throughput
Default `rebaseWhen: auto` + `automerge: true` rebases every behind-base branch, so only **one PR merged per run**. `conflicted` rebases only on a real conflict, so all green PRs **merge in a single run**. GitHub allows it (ruleset status policy is non-strict; squash/rebase keeps history linear). Majors are unaffected.

## 2. Schedule 8h → 4h — latency
`0 */8 * * *` → `0 */4 * * *`. Fresh minor/patch PRs merge within ~4h.

## 3. Fix 1Password CLI datasource (the `no-result` error)
`1Password/1password-cli` is a 404 — op is published on agilebits, not GitHub, so `github-releases` never resolved. Replaced with a custom `html` datasource on the CLI2 product-history page + `extractVersion` regex (`op2/pkg/(?<version>v[^/]+)/op_linux_amd64_`). Verified against the live page: yields clean versions (`…v2.34.0, v2.34.1`); betas are semver prereleases → skipped by `ignoreUnstable`. Effect: `v2.34.0 → v2.34.1` (patch → auto-merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)