### PR TITLE
fix(renovate): track 1Password CLI via custom datasource

### DIFF
--- a/images/openclaw/Dockerfile
+++ b/images/openclaw/Dockerfile
@@ -5,7 +5,7 @@ FROM ghcr.io/openclaw/openclaw:${OPENCLAW_VERSION}
 
 USER root
 
-# renovate: datasource=github-releases depName=1Password/1password-cli
+# renovate: datasource=custom.1password-cli depName=1password-cli
 ARG OP_CLI_VERSION=v2.34.0
 
 RUN apt-get update \

--- a/renovate.json
+++ b/renovate.json
@@ -5,12 +5,24 @@
     "helpers:pinGitHubActionDigests",
     ":disableRateLimiting"
   ],
+  "customDatasources": {
+    "1password-cli": {
+      "defaultRegistryUrlTemplate": "https://app-updates.agilebits.com/product_history/CLI2",
+      "format": "html"
+    }
+  },
   "packageRules": [
     {
       "description": "Automerge non-major updates; only major needs manual approval",
       "matchUpdateTypes": ["minor", "patch", "digest", "pin", "pinDigest"],
       "automerge": true,
       "platformAutomerge": false
+    },
+    {
+      "description": "1Password CLI publishes via agilebits, not GitHub; pull the version out of the download links",
+      "matchDatasources": ["custom.1password-cli"],
+      "extractVersion": "op2/pkg/(?<version>v[^/]+)/op_linux_amd64_",
+      "versioning": "semver"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Problem
Renovate logs: `Failed to look up github-releases package 1Password/1password-cli: no-result`.

`1Password/1password-cli` is **not a public GitHub repo** (404) — the op CLI is published on `cache.agilebits.com`, not GitHub releases. So `datasource=github-releases` can never resolve.

## Fix
- **Custom datasource** `1password-cli` → the CLI2 product-history page (`https://app-updates.agilebits.com/product_history/CLI2`), parsed as `html` (Renovate turns every `<a href>` into a candidate).
- **`extractVersion`** pulls the version out of the linux/amd64 download links: `op2/pkg/(?<version>v[^/]+)/op_linux_amd64_`.
- Dockerfile annotation switched to `datasource=custom.1password-cli depName=1password-cli`.

## Verified against the live page
Extraction yields clean versions (`…v2.33.1, v2.34.0, v2.34.1`) plus betas (`v2.36.0-beta.03`, …). Betas are semver prereleases → skipped by `ignoreUnstable` while pinned to a stable version.

Result: current `v2.34.0` → latest stable `v2.34.1` (a patch bump, so it auto-merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)