### PR TITLE
Add Paperclip image with Claude Code and Codex CLIs

### DIFF
--- a/images/paperclip/Dockerfile
+++ b/images/paperclip/Dockerfile
@@ -1,0 +1,16 @@
+# Paperclip doesn't publish semver tags yet, only `latest` and per-commit
+# `sha-<hash>` tags, so we pin to a specific commit tag for reproducibility.
+# renovate: datasource=docker depName=ghcr.io/paperclipai/paperclip
+ARG PAPERCLIP_VERSION=sha-903886b
+
+FROM ghcr.io/paperclipai/paperclip:${PAPERCLIP_VERSION}
+
+USER root
+
+# Local adapters (Claude Code, Codex) spawn these CLIs as subprocesses on
+# the same container as the Paperclip server, so they need to be installed
+# here rather than reached over the network.
+RUN npm install -g @anthropic-ai/claude-code @openai/codex \
+    && rm -rf /root/.npm
+
+USER 1000:1000


### PR DESCRIPTION
## Summary
- Adds `images/paperclip/Dockerfile`, built on the upstream `ghcr.io/paperclipai/paperclip` image
- Installs `@anthropic-ai/claude-code` and `@openai/codex` globally on top of it

Paperclip's built-in local adapters (Claude Code, Codex) work by spawning the CLI as a subprocess on the same machine as the Paperclip server — there's no network hop. So both CLIs need to live in the same image as the server itself for the homelab deployment to be able to use them.

## Test plan
- [ ] CI build succeeds via the changed-images matrix in `.github/workflows/build.yaml`
- [ ] `claude --version` and `codex --version` both work in the built image


---
_Generated by [Claude Code](https://claude.ai/code/session_019SFmtapbZQKKwDFZkjAFRe)_